### PR TITLE
Add translation for deposit location prompt

### DIFF
--- a/app/(tabs)/Deposit.tsx
+++ b/app/(tabs)/Deposit.tsx
@@ -96,6 +96,16 @@ export default function Deposit() {
         customElement={<DepositFormCheckBox />}
       />
 
+      <Text
+        style={{
+          paddingTop: 10,
+          paddingHorizontal: 10,
+          color: Colors[colorScheme].text,
+        }}
+      >
+        {i18n.t('deposit_choose_location')}
+      </Text>
+
       <View
         style={{
           backgroundColor: Colors[colorScheme].highlight,

--- a/translationService/ar.ts
+++ b/translationService/ar.ts
@@ -53,6 +53,8 @@ const arDictionary: Dictionary = {
   deposit_form_amount: 'الكمية',
   deposit_form_kilogram: 'كغ',
 
+  deposit_choose_location: 'اختر موقع الإيداع',
+
   location: 'اختر موقعًا من القائمة المنسدلة',
   deposit_compost_stand_blank: '',
   deposit_compost_stand_cafe_shapira: 'مقهى شفيرا',

--- a/translationService/en.ts
+++ b/translationService/en.ts
@@ -59,6 +59,8 @@ const enDictionary: Dictionary = {
   deposit_form_amount: 'Amount',
   deposit_form_kilogram: 'kg',
 
+  deposit_choose_location: 'Choose deposit location',
+
   compost_report_title: 'What\'s the status',
   compost_report_bin_full: 'compost bin full',
   compost_report_bin_smells: 'compost smells',

--- a/translationService/he.ts
+++ b/translationService/he.ts
@@ -59,6 +59,8 @@ const heDictionary: Dictionary = {
   deposit_form_amount: 'כמות',
   deposit_form_kilogram: 'קילו',
 
+  deposit_choose_location: 'בחר מיקום הפקדה',
+
   location: 'בחר מיקום מתפריט גלילה',
   deposit_compost_stand_blank: '',
   deposit_compost_stand_cafe_shapira: 'קפה שפירא ',

--- a/types/translation.ts
+++ b/types/translation.ts
@@ -57,6 +57,7 @@ export type DictionaryKey =
   'deposit_form_notes' |
   'deposit_form_amount' |
   'deposit_form_kilogram' |
+  'deposit_choose_location' |
 
   // COMPOST STANDS
   'location' |


### PR DESCRIPTION
## Summary
- support new `deposit_choose_location` translation
- show translated prompt above compost stand picker on deposit page

## Testing
- `npm test -- -w=0` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c27240f1c83239faa04e4c79ac34d